### PR TITLE
Adding GITHUB_RUN_ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@ function getBuildNumber() {
          process.env.CI_BUILD_NUMBER ||
          process.env.CIRCLE_BUILD_NUM ||
          process.env.TRAVIS_BUILD_NUMBER ||
-         process.env.APPVEYOR_BUILD_NUMBER
-         process.env.bamboo_buildNumber;
+         process.env.APPVEYOR_BUILD_NUMBER ||
+         process.env.bamboo_buildNumber ||
+         process.env.GITHUB_RUN_ID;
 }
 
 module.exports = getBuildNumber;


### PR DESCRIPTION
With github actions becoming more popular, the [GITHUB_RUN_ID](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) seems like a good addition.

_Note:_ This PR should also fix bamboo_buildNumber in the process.